### PR TITLE
Add a pull request template for PRs in rust-vmm

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,14 @@
+### Summary of the PR
+
+*Please summarize here why the changes in this PR are needed.*
+
+### Requirements
+
+Before submitting your PR, please make sure you addressed the following
+requirements:
+
+- [ ] All commits in this PR are signed (with `git commit -s`), and follow
+  [the 50/72 git commit rule](https://www.midori-global.com/blog/2018/04/02/git-50-72-rule).
+- [ ] All added/changed functionality has a corresponding unit/integration
+  test.
+- [ ] Any newly added `unsafe` code is properly documented.


### PR DESCRIPTION
Make some of the most important requirements for a PR more obvious, by adding a pull request template file.