### PR TITLE
enable dependency updates for rust crates

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -4,4 +4,12 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 1
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 1
+  allow:
+  - dependency-type: direct
+  - dependency-type: indirect


### PR DESCRIPTION
### Summary of the PR

We now use caret dependencies for rust-vmm. This makes sure that dependencies don't rot.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
